### PR TITLE
Fix "Visual Bug" in FAQ

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -198,7 +198,7 @@ export default function Home() {
               >
                 FAQ
               </Heading>
-              <Accordion mt={8} allowMultiple defaultIndex={[0]}>
+              <Accordion mt={8} allowMultiple>
                 {FAQ.map((faq, index) => (
                   <AccordionItem key={index} color="white">
                     <AccordionButton


### PR DESCRIPTION
![image](https://github.com/azka-siddiqui/webapp-steming-up/assets/61215237/b8ded7f3-6d9c-46dd-91d9-bd9da89ff834)

Noticed this visual bug where first item of FAQ would be, by default, opened, so I was wondering if you wanted to make the FAQ section cleaner.